### PR TITLE
fix: source maps present in published package causes warnings during …

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "url": "https://github.com/VirtuslabRnD/react-oauth2.git"
   },
   "scripts": {
-    "build": "tsc",
+    "clean": "rm -rf ./lib",
+    "build:dev": "yarn clean && tsc",
+    "build": "yarn clean && tsc -p tsconfig.prod.json",
     "test": "jest --env=jsdom",
     "test:ci": "yarn test --ci",
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virtuslab/react-oauth2",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "",
   "author": "Adam Kusmierz <adam@kusmierz.be>",
   "homepage": "https://github.com/VirtusLabRnD/react-oauth2#readme",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "sourceMap": false
+  }
+}


### PR DESCRIPTION
…webpack build

Despite being published, package contains references to source
maps which cannot be loaded via webpack source-maps loader due
to the lack of src/ directory which causes a nasty set of warnings.

This fix change a way of how package is built by disabling
source-maps for production builds.